### PR TITLE
Update plugin build for SonarQube 9.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,11 +230,11 @@ Once you run the command, you will see the project and the information about it 
 ### Try it out
 
 ```cmd
-docker pull fperezpa/mulesonarqube:7.7.3
-docker run -d --name sonarqube -p 9000:9000 -p 9092:9092 fperezpa/mulesonarqube:7.7.3
+docker pull fperezpa/mulesonarqube:9.9.0
+docker run -d --name sonarqube -p 9000:9000 -p 9092:9092 fperezpa/mulesonarqube:9.9.0
 ```
 *Disclaimer*
-The docker image is based on the official SonarQube Image, *sonarqube:7.7-community*. For more information please visit, https://hub.docker.com/_/sonarqube/
+The docker image is based on the official SonarQube Image, *sonarqube:9.9-community*. For more information please visit, https://hub.docker.com/_/sonarqube/
 
 
 ## Final Notes

--- a/pom.xml
+++ b/pom.xml
@@ -13,12 +13,12 @@
 
 
 	<properties>
-		<maven.compiler.target>1.8</maven.compiler.target>
-		<maven.compiler.source>1.8</maven.compiler.source>
+                <maven.compiler.target>11</maven.compiler.target>
+                <maven.compiler.source>11</maven.compiler.source>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<sonar.apiVersion>7.7</sonar.apiVersion>
-		<jaxb.api.version>2.3.3</jaxb.api.version>
-		<jaxb.version>2.3.2</jaxb.version>
+                <sonar.apiVersion>9.9</sonar.apiVersion>
+                <jaxb.api.version>3.0.1</jaxb.api.version>
+                <jaxb.version>3.0.2</jaxb.version>
 	</properties>
 
 	<dependencies>
@@ -39,32 +39,32 @@
 		<dependency>
 			<groupId>org.sonarsource.analyzer-commons</groupId>
 			 <artifactId>sonar-xml-parsing</artifactId>
-			 <version>1.12.0.632</version>
+                         <version>1.14.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jdom</groupId>
 			<artifactId>jdom2</artifactId>
-			<version>2.0.6</version>
+                        <version>2.0.6.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.25</version>
+                        <version>1.7.36</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j-impl</artifactId>
-			<version>2.17.2</version>
+                        <version>2.20.0</version>
 		</dependency>
 		<dependency>
 			<groupId>jaxen</groupId>
 			<artifactId>jaxen</artifactId>
-			<version>1.1.6</version>
+                        <version>1.2.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.12.6.1</version>
+                        <version>2.15.2</version>
 		</dependency>
 
 		<!-- Compliance JAVA 11 -->
@@ -72,19 +72,19 @@
 		<dependency>
 			<groupId>jakarta.xml.bind</groupId>
 			<artifactId>jakarta.xml.bind-api</artifactId>
-			<version>${jaxb.api.version}</version>
+                        <version>${jaxb.api.version}</version>
 		</dependency>
 		<!-- Runtime -->
 		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>
 			<artifactId>jaxb-runtime</artifactId>
-			<version>${jaxb.version}</version>
+                        <version>${jaxb.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>javax.activation</groupId>
 			<artifactId>activation</artifactId>
-			<version>1.1</version>
+                        <version>1.2.0</version>
 		</dependency>
 	</dependencies>
 	<build>
@@ -93,7 +93,7 @@
 			<plugin>
 				<groupId>org.sonarsource.sonar-packaging-maven-plugin</groupId>
 				<artifactId>sonar-packaging-maven-plugin</artifactId>
-				<version>1.17</version>
+                                <version>1.20</version>
 				<extensions>true</extensions>
 				<configuration>
 					<!-- the entry-point class that extends org.sonar.api.SonarPlugin -->


### PR DESCRIPTION
## Summary
- update Java compiler level to 11
- update SonarQube API to 9.9
- refresh dependency versions
- update packaging plugin version
- adjust README example to use SonarQube 9.9 image

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855163163508332b4b27e752265e0e0